### PR TITLE
Fix build with JDK10

### DIFF
--- a/geotriples-core/pom.xml
+++ b/geotriples-core/pom.xml
@@ -17,9 +17,9 @@
 	</licenses>
 	<properties>
 		<slf4j.version>1.6.4</slf4j.version>
-		<geotools.version>13.2</geotools.version>
+		<geotools.version>20.0</geotools.version>
 		<junit.version>4.11</junit.version>
-		<jts.version>1.13</jts.version>
+		<jts.version>1.16.0</jts.version>
 		<skipTests>true</skipTests>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.targetEncoding>UTF-8</project.build.targetEncoding>

--- a/geotriples-core/src/main/java/eu/linkedeodata/geotriples/GeoTriplesCMD.java
+++ b/geotriples-core/src/main/java/eu/linkedeodata/geotriples/GeoTriplesCMD.java
@@ -1,6 +1,5 @@
 package eu.linkedeodata.geotriples;
 
-import java.io.FileOutputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;

--- a/geotriples-core/src/main/java/eu/linkedeodata/geotriples/dump_rdf.java
+++ b/geotriples-core/src/main/java/eu/linkedeodata/geotriples/dump_rdf.java
@@ -218,7 +218,6 @@ public class dump_rdf {
 				pipeargs=new String[]{cmd.getItem(0),cmd.getArg(outfileArg).getValue()};
 				//log.info("DERP");
 			}*/
-			HelpFormatter hh=new HelpFormatter();
 			MainTrans.main(pipeargs);
 			
 			return;

--- a/geotriples-evaluation/pom.xml
+++ b/geotriples-evaluation/pom.xml
@@ -17,9 +17,9 @@
 	</licenses>
 	<properties>
 		<slf4j.version>1.6.4</slf4j.version>
-		<geotools.version>13.2</geotools.version>
+		<geotools.version>20.0</geotools.version>
 		<junit.version>4.11</junit.version>
-		<jts.version>1.13</jts.version>
+		<jts.version>1.16.0</jts.version>
 		<skipTests>true</skipTests>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.targetEncoding>UTF-8</project.build.targetEncoding>

--- a/geotriples-gui/pom.xml
+++ b/geotriples-gui/pom.xml
@@ -17,14 +17,15 @@
 	</licenses>
 	<properties>
 		<slf4j.version>1.6.4</slf4j.version>
-		<geotools.version>13.2</geotools.version>
+		<geotools.version>20.0</geotools.version>
 		<junit.version>4.11</junit.version>
-		<jts.version>1.13</jts.version>
+		<jts.version>1.16.0</jts.version>
 		<skipTests>true</skipTests>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.targetEncoding>UTF-8</project.build.targetEncoding>
 		<github.global.server>github-geotriples</github.global.server>
 		<maven.javadoc.skip>true</maven.javadoc.skip>
+		<pivot.version>2.0.5</pivot.version>
 	</properties>
 	<parent>
         <groupId>eu.linkedeodata.geotriples</groupId>
@@ -33,59 +34,37 @@
     </parent>
 
 	<dependencies>
-		<!-- 
-<dependency>
-            <groupId>eu.linkedeodata.geotriples</groupId>
-            <artifactId>SystemEvaluation</artifactId>
-            <version>1.1.6-SNAPSHOT</version>
-        </dependency>
 		<dependency>
-            <groupId>org.d2rq</groupId>
-            <artifactId>R2RMLprocessor</artifactId>
-            <version>1.1.6-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>be.ugent.mmlab.rml</groupId>
-            <artifactId>RMLprocessor</artifactId>
-            <version>1.1.6-SNAPSHOT</version>
-        </dependency>
- -->
- 		<dependency>
-            <groupId>eu.linkedeodata.geotriples</groupId>
-            <artifactId>geotriples-core</artifactId>
-            <version>1.1.6-SNAPSHOT</version>
-        </dependency>
-        
-        <dependency>
+			<groupId>eu.linkedeodata.geotriples</groupId>
+			<artifactId>geotriples-core</artifactId>
+			<version>1.1.6-SNAPSHOT</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.apache.pivot</groupId>
 			<artifactId>pivot-core</artifactId>
-			<version>2.0.4</version>
+			<version>${pivot.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.pivot</groupId>
 			<artifactId>pivot-wtk</artifactId>
-			<version>2.0.4</version>
+			<version>${pivot.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.pivot</groupId>
 			<artifactId>pivot-web</artifactId>
-			<version>2.0.4</version>
+			<version>${pivot.version}</version>
 		</dependency>
 		<dependency>
-		<groupId>org.apache.pivot</groupId>
-		<artifactId>pivot-wtk-terra</artifactId>
-		<version>2.0.4</version>
+			<groupId>org.apache.pivot</groupId>
+			<artifactId>pivot-wtk-terra</artifactId>
+			<version>${pivot.version}</version>
 		</dependency>
-		<!-- <dependency> -->
-		<!-- <groupId>org.apache.pivot</groupId> -->
-		<!-- <artifactId>pivot-charts</artifactId> -->
-		<!-- <version>2.0.4</version> -->
-		<!-- </dependency> -->
 		
 		<dependency>
 			<groupId>org.codehaus.mojo.appassembler</groupId>
 			<artifactId>appassembler-booter</artifactId>
-			<version>1.10</version>
+			<version>2.0.0</version>
 		</dependency>
 		
 	</dependencies>
@@ -94,10 +73,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
+				<version>3.8.0</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<encoding>utf8</encoding>
 				</configuration>
 			</plugin>
@@ -105,7 +84,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.17</version>
+				<version>2.22.0</version>
 				<configuration>
 					<skipTests>${skipTests}</skipTests>
 				</configuration>
@@ -113,21 +92,15 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5.1</version>
+				<version>2.5.3</version>
 				<configuration>
 					<tagNameFormat>v@{project.version}</tagNameFormat>
 				</configuration>
 			</plugin>
-			
-			
-			
-
-			
-			
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.10.1</version>
+				<version>3.0.1</version>
 				<configuration>
 					<skip>true</skip>
 				</configuration>
@@ -137,7 +110,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>appassembler-maven-plugin</artifactId>
-				<version>1.10</version>
+				<version>2.0.0</version>
 				<configuration>
 					<daemons>
 						<daemon>
@@ -162,7 +135,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>2.6</version>
+				<version>3.1.0</version>
 				<executions>
 					<execution>
 						<phase>package</phase>
@@ -172,7 +145,9 @@
 					</execution>
 				</executions>
 				<configuration>
-					<descriptor>src/main/assembly/bin.xml</descriptor>
+					<descriptors>
+						<descriptor>src/main/assembly/bin.xml</descriptor>
+					</descriptors>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/geotriples-gui/src/main/java/eu/linkedeodata/geotriples/gui/GeoTriples.java
+++ b/geotriples-gui/src/main/java/eu/linkedeodata/geotriples/gui/GeoTriples.java
@@ -17,7 +17,6 @@
 package eu.linkedeodata.geotriples.gui;
 
 import java.net.URL;
-import java.security.Permission;
 import java.util.Locale;
 
 import org.apache.pivot.beans.BXMLSerializer;
@@ -27,34 +26,24 @@ import org.apache.pivot.wtk.Application;
 import org.apache.pivot.wtk.DesktopApplicationContext;
 import org.apache.pivot.wtk.Display;
 
-import sun.applet.AppletClassLoader;
-
 /**
  * Stock Tracker application.
  */
 public class GeoTriples implements Application{
-	
+
     private GeoTriplesWindow window = null;
 
     public static final String LANGUAGE_KEY = "language";
 
     @Override
     public void startup(Display display, Map<String, String> properties) throws Exception {
-    	
-    	ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-    	//classLoader.loadClass(GeoTriplesWindow.class.getName());
-    	//System.out.println(classLoader);
-       // URL resource = classLoader.getResource("/");  
-       //System.out.println(resource);
-    	//Resources fff=new 
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
         String language = properties.get(LANGUAGE_KEY);
-        System.out.println(language); //na to dw kati paei x edw
-        //Locale locale = (language == null) ? Locale.ENGLISH : new Locale(language);
+        System.out.println(language);
         Locale locale = (language == null) ? Locale.getDefault() : new Locale(language);
         System.out.println(locale);
-        //Resources resources = new Resources(GeoTriplesWindow.class.getName(),locale);
         @SuppressWarnings("unused")
-		URL url=classLoader.getResource("GeoTriplesWindow.json");
+        URL url=classLoader.getResource("GeoTriplesWindow.json");
         
         Resources resources = new Resources("GeoTriplesWindow",locale);
         BXMLSerializer bxmlSerializer = new BXMLSerializer();
@@ -62,17 +51,7 @@ public class GeoTriples implements Application{
         System.out.println(classLoader.getResource("/GeoTriplesWindow.bxml"));
         System.out.println(GeoTriples.class.getResource("GeoTriplesWindow.bxml"));
         System.out.println(GeoTriples.class.getResource("/GeoTriplesWindow.bxml"));
-        
-        //System.out.println(AppletClassLoader.getSystemResource("GeoTriplesWindow.bxml"));
-        //System.out.println(AppletClassLoader.getSystemResource("/GeoTriplesWindow.bxml"));
-        
-        //System.out.println(GeoTriples.class.getClassLoader().getResource("GeoTriplesWindow.bxml"));
-        //System.out.println(GeoTriples.class.getClassLoader().getResource("/GeoTriplesWindow.bxml"));
-        
-        //ClassLoader.getSystemClassLoader().getResource("GeoTriplesWindow.bxml");
-        //ClassLoader.getSystemClassLoader().getResource("/GeoTriplesWindow.bxml");
         window = (GeoTriplesWindow)bxmlSerializer.readObject(classLoader.getResource("GeoTriplesWindow.bxml"),resources);
-        //window = (GeoTriplesWindow)bxmlSerializer.readObject(classLoader.getResourceAsStream("GeoTriplesWindow.bxml"));
         window.open(display);
     }
 

--- a/geotriples-ontop/pom.xml
+++ b/geotriples-ontop/pom.xml
@@ -17,9 +17,9 @@
 	</licenses>
 	<properties>
 		<slf4j.version>1.6.4</slf4j.version>
-		<geotools.version>13.2</geotools.version>
+		<geotools.version>20.0</geotools.version>
 		<junit.version>4.11</junit.version>
-		<jts.version>1.13</jts.version>
+		<jts.version>1.16.0</jts.version>
 		<skipTests>true</skipTests>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.targetEncoding>UTF-8</project.build.targetEncoding>

--- a/geotriples-processors/geotriples-r2rml/pom.xml
+++ b/geotriples-processors/geotriples-r2rml/pom.xml
@@ -17,9 +17,9 @@
 	</licenses>
 	<properties>
 		<slf4j.version>1.6.4</slf4j.version>
-		<geotools.version>13.2</geotools.version>
+		<geotools.version>20.0</geotools.version>
 		<junit.version>4.11</junit.version>
-		<jts.version>1.13</jts.version>
+		<jts.version>1.16.0</jts.version>
 		<skipTests>true</skipTests>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.targetEncoding>UTF-8</project.build.targetEncoding>

--- a/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/GTransormationFunctions.java
+++ b/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/GTransormationFunctions.java
@@ -2,9 +2,9 @@ package eu.linkedeodata.geotriples;
 
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.WKTWriter;
-import com.vividsolutions.jts.io.gml2.GMLWriter;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.WKTWriter;
+import org.locationtech.jts.io.gml2.GMLWriter;
 
 public final class GTransormationFunctions {
 	private static WKTWriter wkt_writer = new WKTWriter();

--- a/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/GeneralR2RMLCompiler.java
+++ b/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/GeneralR2RMLCompiler.java
@@ -64,7 +64,6 @@ import org.d2rq.values.TemplateValueMaker;
 import org.d2rq.values.TemplateValueMaker.ColumnFunction;
 import org.d2rq.values.TransformationValueMaker;
 import org.d2rq.values.ValueMaker;
-import org.hamcrest.core.IsInstanceOf;
 
 import com.hp.hpl.jena.datatypes.TypeMapper;
 import com.hp.hpl.jena.graph.Graph;

--- a/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/RowHandler.java
+++ b/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/RowHandler.java
@@ -1,9 +1,9 @@
 package eu.linkedeodata.geotriples;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.io.WKTWriter;
-import com.vividsolutions.jts.io.gml2.GMLWriter;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.io.WKTWriter;
+import org.locationtech.jts.io.gml2.GMLWriter;
 
 public class RowHandler {
 	public static void handleGeometry(GeneralResultRow row,Geometry g,String crs)
@@ -15,8 +15,8 @@ public class RowHandler {
 		WKTWriter wkt_writer = new WKTWriter();
 		GMLWriter gml_writer = new GMLWriter();
 		if (g.getClass().equals(
-				com.vividsolutions.jts.geom.Point.class)) {
-			Point geometry = (com.vividsolutions.jts.geom.Point) g;
+				org.locationtech.jts.geom.Point.class)) {
+			Point geometry = (org.locationtech.jts.geom.Point) g;
 			row.addPair("isEmpty", geometry.isEmpty());
 			row.addPair("isSimple", geometry.isSimple());
 			row.addPair("dimension",

--- a/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/geotiff/GeoTiffParser.java
+++ b/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/geotiff/GeoTiffParser.java
@@ -33,10 +33,10 @@ import org.opengis.feature.Feature;
 import org.opengis.feature.GeometryAttribute;
 import org.opengis.feature.Property;
 
-import com.vividsolutions.jts.geom.GeometryCollection;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.io.WKTWriter;
-import com.vividsolutions.jts.io.gml2.GMLWriter;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.io.WKTWriter;
+import org.locationtech.jts.io.gml2.GMLWriter;
 
 public class GeoTiffParser {
 	private File geoTiffFile;
@@ -100,7 +100,7 @@ public class GeoTiffParser {
 				Object initgeometry = null;
 				if (sourceGeometryAttribute.getValue().toString()
 						.startsWith("POINT")) {
-					Point geometry = (com.vividsolutions.jts.geom.Point) sourceGeometryAttribute
+					Point geometry = (org.locationtech.jts.geom.Point) sourceGeometryAttribute
 							.getValue();
 					newrow.addPair("isEmpty", geometry.isEmpty());
 					newrow.addPair("isSimple", geometry.isSimple());

--- a/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/geotiff/GeoTiffReaderExample.java
+++ b/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/geotiff/GeoTiffReaderExample.java
@@ -1,6 +1,6 @@
 package eu.linkedeodata.geotriples.geotiff;
 
-//package com.vividsolutions.jtsexample.io.gml2;
+//package org.locationtech.jtsexample.io.gml2;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -20,18 +20,18 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 
-import com.vividsolutions.jts.geom.CoordinateSequence;
-import com.vividsolutions.jts.geom.CoordinateSequenceFactory;
-import com.vividsolutions.jts.geom.CoordinateSequences;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryCollection;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LinearRing;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.io.WKTWriter;
-import com.vividsolutions.jts.io.gml2.GMLConstants;
-import com.vividsolutions.jts.io.gml2.GMLHandler;
-import com.vividsolutions.jts.io.gml2.GMLWriter;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateSequenceFactory;
+import org.locationtech.jts.geom.CoordinateSequences;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.io.WKTWriter;
+import org.locationtech.jts.io.gml2.GMLConstants;
+import org.locationtech.jts.io.gml2.GMLHandler;
+import org.locationtech.jts.io.gml2.GMLWriter;
 
 /**
  * An example of using the {@link GMLHandler} class to read geometry data out of
@@ -212,8 +212,8 @@ private class KMLHandler extends DefaultHandler {
 				
 				WKTWriter wkt_writer=new WKTWriter();
 				GMLWriter gml_writer = new GMLWriter();
-				if (g.getClass().equals(com.vividsolutions.jts.geom.Point.class)) {
-					Point geometry = (com.vividsolutions.jts.geom.Point) g;
+				if (g.getClass().equals(org.locationtech.jts.geom.Point.class)) {
+					Point geometry = (org.locationtech.jts.geom.Point) g;
 					row.addPair("isEmpty", geometry.isEmpty());
 					row.addPair("isSimple", geometry.isSimple());
 					row.addPair("dimension",

--- a/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/kml/KMLManagement.java
+++ b/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/kml/KMLManagement.java
@@ -1,6 +1,6 @@
 package eu.linkedeodata.geotriples.kml;
 
-//package com.vividsolutions.jtsexample.io.gml2;
+//package org.locationtech.jtsexample.io.gml2;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -20,14 +20,14 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.DefaultHandler;
 
-import com.vividsolutions.jts.geom.CoordinateSequence;
-import com.vividsolutions.jts.geom.CoordinateSequenceFactory;
-import com.vividsolutions.jts.geom.CoordinateSequences;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LinearRing;
-import com.vividsolutions.jts.io.gml2.GMLConstants;
-import com.vividsolutions.jts.io.gml2.GMLHandler;
+import org.locationtech.jts.geom.CoordinateSequence;
+import org.locationtech.jts.geom.CoordinateSequenceFactory;
+import org.locationtech.jts.geom.CoordinateSequences;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.io.gml2.GMLConstants;
+import org.locationtech.jts.io.gml2.GMLHandler;
 
 import eu.linkedeodata.geotriples.GeneralResultRow;
 import eu.linkedeodata.geotriples.KeyGenerator;

--- a/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/kml/KMLParser.java
+++ b/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/kml/KMLParser.java
@@ -37,7 +37,7 @@ import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Geometry;
 
 import eu.linkedeodata.geotriples.GeneralParser;
 import eu.linkedeodata.geotriples.GeneralResultRow;

--- a/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/shapefile/ShapeFileParser.java
+++ b/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/shapefile/ShapeFileParser.java
@@ -34,7 +34,7 @@ import org.opengis.feature.type.PropertyDescriptor;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Geometry;
 
 import eu.linkedeodata.geotriples.PrintTimeStats;
 import eu.linkedeodata.geotriples.Config;

--- a/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/shapefile/ShapefileCommandLineTool.java
+++ b/geotriples-processors/geotriples-r2rml/src/main/java/eu/linkedeodata/geotriples/shapefile/ShapefileCommandLineTool.java
@@ -62,7 +62,7 @@ public abstract class ShapefileCommandLineTool {
 	{
 		this.process(args, null, null);
 	}
-	public void process(String[] args,RecipeMapping receipt) throws Exception
+	public void process(String[] args, RecipeMapping receipt) throws Exception
 	{
 		if(receipt==null)
 		{

--- a/geotriples-processors/geotriples-r2rml/src/main/java/org/d2rq/nodes/TypedNodeTransformationMaker.java
+++ b/geotriples-processors/geotriples-r2rml/src/main/java/org/d2rq/nodes/TypedNodeTransformationMaker.java
@@ -8,7 +8,7 @@ import org.d2rq.values.ValueMaker;
 import org.d2rq.vocab.GEOMETRY_FUNCTIONS;
 
 import com.hp.hpl.jena.graph.Node;
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Geometry;
 
 import eu.linkedeodata.geotriples.GTransormationFunctions;
 import eu.linkedeodata.geotriples.GeneralConnection;

--- a/geotriples-processors/geotriples-r2rml/src/main/java/org/d2rq/nodes/TypedNodeTransformationMakerList.java
+++ b/geotriples-processors/geotriples-r2rml/src/main/java/org/d2rq/nodes/TypedNodeTransformationMakerList.java
@@ -11,7 +11,7 @@ import org.d2rq.vocab.GEOMETRY_FUNCTIONS;
 import org.d2rq.vocab.STRING_FUNCTIONS;
 
 import com.hp.hpl.jena.graph.Node;
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Geometry;
 
 import eu.linkedeodata.geotriples.GTransormationFunctions;
 import eu.linkedeodata.geotriples.GeneralConnection;

--- a/geotriples-processors/geotriples-r2rml/src/main/java/org/d2rq/values/TransformationValueMaker.java
+++ b/geotriples-processors/geotriples-r2rml/src/main/java/org/d2rq/values/TransformationValueMaker.java
@@ -20,7 +20,7 @@ import org.d2rq.vocab.STRING_FUNCTIONS;
 import org.gdal.ogr.ogr;
 import org.gdal.ogr.ogrJNI;
 
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Geometry;
 
 import eu.linkedeodata.geotriples.Config;
 import eu.linkedeodata.geotriples.PrintTimeStats;

--- a/geotriples-processors/geotriples-rml/pom.xml
+++ b/geotriples-processors/geotriples-rml/pom.xml
@@ -17,9 +17,7 @@
 	</licenses>
 	<properties>
 		<slf4j.version>1.6.4</slf4j.version>
-		<geotools.version>13.2</geotools.version>
-		<junit.version>4.11</junit.version>
-		<jts.version>1.13</jts.version>
+		<jts.version>1.16.0</jts.version>
 		<skipTests>true</skipTests>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.targetEncoding>UTF-8</project.build.targetEncoding>
@@ -170,8 +168,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<encoding>utf8</encoding>
 				</configuration>
 			</plugin>
@@ -192,12 +190,6 @@
 					<tagNameFormat>v@{project.version}</tagNameFormat>
 				</configuration>
 			</plugin>
-			
-			
-			
-
-			
-			
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
@@ -219,6 +211,14 @@
 	</build>
 	
 	<repositories>
+		<repository>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<id>central</id>
+			<name>Maven Repository Switchboard</name>
+			<url>http://repo1.maven.org/maven2</url>
+		</repository>
 		<!-- Temporary: MonetDB jdbc -->
 		<repository>
 			<releases>

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/AbstractFunction.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/AbstractFunction.java
@@ -16,10 +16,10 @@ import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.NoSuchAuthorityCodeException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKTReader;
-import com.vividsolutions.jts.io.gml2.GMLReader;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+import org.locationtech.jts.io.gml2.GMLReader;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import be.ugent.mmlab.rml.tools.CacheFifo;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionArea.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionArea.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import be.ugent.mmlab.rml.vocabulary.Vocab.QLTerm;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionAsGML.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionAsGML.java
@@ -10,8 +10,8 @@ import org.geotools.referencing.CRS;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import eu.linkedeodata.geotriples.PrintTimeStats;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionAsWKT.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionAsWKT.java
@@ -10,8 +10,8 @@ import org.geotools.referencing.CRS;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import eu.linkedeodata.geotriples.PrintTimeStats;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionCentroidX.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionCentroidX.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import be.ugent.mmlab.rml.vocabulary.Vocab.QLTerm;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionCentroidY.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionCentroidY.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import be.ugent.mmlab.rml.vocabulary.Vocab.QLTerm;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionContains.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionContains.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import be.ugent.mmlab.rml.vocabulary.Vocab.QLTerm;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionCoordinateDimension.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionCoordinateDimension.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import be.ugent.mmlab.rml.vocabulary.Vocab.QLTerm;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionCrosses.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionCrosses.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import be.ugent.mmlab.rml.vocabulary.Vocab.QLTerm;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionDimension.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionDimension.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import eu.linkedeodata.geotriples.PrintTimeStats;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionDisjoint.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionDisjoint.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import be.ugent.mmlab.rml.vocabulary.Vocab.QLTerm;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionDistance.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionDistance.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import be.ugent.mmlab.rml.vocabulary.Vocab.QLTerm;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionEquals.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionEquals.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import be.ugent.mmlab.rml.vocabulary.Vocab.QLTerm;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionHasSerialization.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionHasSerialization.java
@@ -10,8 +10,8 @@ import org.geotools.referencing.CRS;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import eu.linkedeodata.geotriples.PrintTimeStats;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionIntersects.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionIntersects.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import be.ugent.mmlab.rml.vocabulary.Vocab.QLTerm;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionIs3D.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionIs3D.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import eu.linkedeodata.geotriples.PrintTimeStats;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionIsEmpty.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionIsEmpty.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import eu.linkedeodata.geotriples.PrintTimeStats;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionIsSimple.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionIsSimple.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import eu.linkedeodata.geotriples.PrintTimeStats;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionLength.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionLength.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import be.ugent.mmlab.rml.vocabulary.Vocab.QLTerm;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionOverlaps.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionOverlaps.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import be.ugent.mmlab.rml.vocabulary.Vocab.QLTerm;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionSpatialDimension.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionSpatialDimension.java
@@ -9,8 +9,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import eu.linkedeodata.geotriples.PrintTimeStats;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionTouches.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionTouches.java
@@ -11,8 +11,8 @@ import org.slf4j.LoggerFactory;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import be.ugent.mmlab.rml.vocabulary.Vocab.QLTerm;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionWithin.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/FunctionWithin.java
@@ -11,8 +11,8 @@ import org.slf4j.LoggerFactory;
 import org.opengis.referencing.FactoryException;
 import org.xml.sax.SAXException;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 
 import be.ugent.mmlab.rml.core.MalformedGeometryException;
 import be.ugent.mmlab.rml.vocabulary.Vocab.QLTerm;

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/GMLConfiguration.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/GMLConfiguration.java
@@ -92,9 +92,9 @@ import org.geotools.xml.Parser;
 import org.geotools.xs.XS;
 import org.picocontainer.MutablePicoContainer;
 
-import com.vividsolutions.jts.geom.CoordinateSequenceFactory;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.impl.CoordinateArraySequenceFactory;
+import org.locationtech.jts.geom.CoordinateSequenceFactory;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.impl.CoordinateArraySequenceFactory;
 
 
 /**

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/GTransormationFunctions.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/function/GTransormationFunctions.java
@@ -7,9 +7,9 @@ package be.ugent.mmlab.rml.function;
 ****************************************************************************/
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.WKTWriter;
-import com.vividsolutions.jts.io.gml2.GMLWriter;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.WKTWriter;
+import org.locationtech.jts.io.gml2.GMLWriter;
 
 public final class GTransormationFunctions {
 	private static WKTWriter wkt_writer = new WKTWriter();

--- a/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/mapgen/CSVMappingGenerator.java
+++ b/geotriples-processors/geotriples-rml/src/main/java/be/ugent/mmlab/rml/mapgen/CSVMappingGenerator.java
@@ -19,8 +19,8 @@ import org.apache.xmlbeans.XmlException;
 import org.geotools.geometry.text.WKTParser;
 
 import com.csvreader.CsvReader;
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKTReader;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 
 import be.ugent.mmlab.rml.core.OntologyGenerator;
 

--- a/geotriples-processors/pom.xml
+++ b/geotriples-processors/pom.xml
@@ -16,10 +16,10 @@
 		</license>
 	</licenses>
 	<properties>
-		<slf4j.version>1.6.4</slf4j.version>
-		<geotools.version>13.2</geotools.version>
+		<slf4j.version>1.7.21</slf4j.version>
+		<geotools.version>20.0</geotools.version>
 		<junit.version>4.11</junit.version>
-		<jts.version>1.13</jts.version>
+		<jts.version>1.16.0</jts.version>
 		<skipTests>true</skipTests>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.targetEncoding>UTF-8</project.build.targetEncoding>
@@ -132,14 +132,12 @@
 
 		</dependency>
 		<dependency>
-			<groupId>
-org.apache.httpcomponents</groupId>
+			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpcore</artifactId>
 			<version>4.1.3</version>
 		</dependency>
 		<dependency>
-			<groupId>
-org.apache.httpcomponents</groupId>
+			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
 			<version>4.1.2</version>
 		</dependency>
@@ -172,8 +170,7 @@ org.apache.httpcomponents</groupId>
 		</dependency>
 		<dependency>
 			<groupId>mysql</groupId>
-			<artifactId>
-mysql-connector-java</artifactId>
+			<artifactId>mysql-connector-java</artifactId>
 			<version>5.1.22</version>
 		</dependency>
 		<dependency>
@@ -201,9 +198,14 @@ mysql-connector-java</artifactId>
 		</dependency>
 		<!-- JTS -->
 		<dependency>
-			<groupId>com.vividsolutions</groupId>
-			<artifactId>jts</artifactId>
+			<groupId>org.locationtech.jts</groupId>
+			<artifactId>jts-core</artifactId>
 			<version>${jts.version}</version>
+		</dependency>
+		<dependency>
+  			<groupId>org.locationtech.jts.io</groupId>
+  			<artifactId>jts-io-common</artifactId>
+  			<version>${jts.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.gdal</groupId>
@@ -231,11 +233,11 @@ mysql-connector-java</artifactId>
 			<artifactId>gt-epsg-hsql</artifactId>
 			<version>${geotools.version}</version>
 		</dependency>
-		<!-- <dependency> -->
-		<!-- <groupId>org.geotools</groupId> -->
-		<!-- <artifactId>gt-shapefile</artifactId> -->
-		<!-- <version>${geotools.version}</version> -->
-		<!-- </dependency> -->
+		<dependency>
+			<groupId>org.geotools</groupId>
+			<artifactId>gt-shapefile</artifactId>
+			<version>${geotools.version}</version>
+		</dependency>
 		<dependency>
 			<groupId>org.geotools</groupId>
 			<artifactId>gt-referencing</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
 	</licenses>
 	<properties>
 		<slf4j.version>1.7.21</slf4j.version>
-		<geotools.version>13.2</geotools.version>
+		<geotools.version>20.0</geotools.version>
 		<junit.version>4.11</junit.version>
-		<jts.version>1.13</jts.version>
+		<jts.version>1.16.0</jts.version>
 		<skipTests>true</skipTests>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.build.targetEncoding>UTF-8</project.build.targetEncoding>


### PR DESCRIPTION
Hi Folks, I closed the source earlier today and tried to both generate mappings and dump RDF for local Shapfile's. I ran into numerous issues with NullPointerExceptions, NumberFormattingExceptions and lots more.
This pull request enables me to build and run ```./bin/geotriples-all``` which produces results, under the following environment
```
Apache Maven 3.5.4 (1edded0938998edf8bf061f1ceb3cfdeccf443fe; 2018-06-17T11:33:14-07:00)
Maven home: /usr/local/Cellar/maven/3.5.4/libexec
Java version: 10.0.2, vendor: Oracle Corporation, runtime: /Library/Java/JavaVirtualMachines/jdk-10.0.2.jdk/Contents/Home
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "10.12.6", arch: "x86_64", family: "mac"
```
In addition, this PR upgrades a few dependencies such as geotools and jtc.
This is a really neat toolkit, thank you for developing. 